### PR TITLE
New way of activating conda environments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,11 @@ Here are the steps::
         --git # for an HTTPS clone
         --git-ssh # for a SSH clone (you need to be a cgat-developer contributor on GitHub to do this)
 
-        # enable the conda environment as requested by the installation script:
-        source </full/path/to/folder/without/trailing/slash>/conda-install/bin/activate cgat-a
+        # enable the conda environment as requested by the installation script
+        # NB: you probably want to automate this by adding the instructions below to your .bashrc
+        source </full/path/to/folder/without/trailing/slash>/conda-install/etc/profile.d/conda.sh cgat-a
+        conda activate base
+        conda activate cgat-a
 
         # finally, please run the cgatflow command-line tool to check the installation:
         cgat --help

--- a/doc/CGATInstallation.rst
+++ b/doc/CGATInstallation.rst
@@ -33,8 +33,11 @@ Here are the steps::
         # or go for the latest development version:
         bash install-CGAT-tools.sh --devel [--location </full/path/to/folder/without/trailing/slash>]
 
-        # enable the conda environment as requested by the installation script:
-        source </full/path/to/folder/without/trailing/slash>/conda-install/bin/activate cgat-s
+        # enable the conda environment as requested by the installation script
+        # NB: you probably want to automate this by adding the instructions below to your .bashrc
+        source </full/path/to/folder/without/trailing/slash>/conda-install/etc/profile.d/conda.sh cgat-a
+        conda activate base
+        conda activate cgat-a
 
         # finally, please run the cgatflow command-line tool to check the installation:
         cgat --help

--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -703,10 +703,11 @@ test_release() {
 
 # test whether a C/C++ compiler is available
 test_compilers() {
-   which gcc &> /dev/null
-   [[ $? -ne 0 ]] && report_error " C compiler not found. "
-   which g++ &> /dev/null
-   [[ $? -ne 0 ]] && report_error " C++ compiler not found. "
+   COMPILER_TEST=0
+   which gcc &> /dev/null || COMPILER_TEST=$?
+   [[ ${COMPILER_TEST} -ne 0 ]] && report_error " C compiler not found. "
+   which g++ &> /dev/null || COMPILER_TEST=$?
+   [[ ${COMPILER_TEST} -ne 0 ]] && report_error " C++ compiler not found. "
 }
 
 # function to display help message

--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -703,11 +703,8 @@ test_release() {
 
 # test whether a C/C++ compiler is available
 test_compilers() {
-   COMPILER_TEST=0
-   which gcc &> /dev/null || COMPILER_TEST=$?
-   [[ ${COMPILER_TEST} -ne 0 ]] && report_error " C compiler not found. "
-   which g++ &> /dev/null || COMPILER_TEST=$?
-   [[ ${COMPILER_TEST} -ne 0 ]] && report_error " C++ compiler not found. "
+   which gcc &> /dev/null || report_error " C compiler not found "
+   which g++ &> /dev/null || report_error " C++ compiler not found "
 }
 
 # function to display help message

--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -434,11 +434,13 @@ if [[ -z ${TRAVIS_INSTALL} ]] ; then
       echo " The code was successfully installed!"
       echo
       echo " To activate the CGAT environment type: "
-      echo " $ source $CONDA_INSTALL_DIR/bin/activate $CONDA_INSTALL_ENV"
+      echo " $ source $CONDA_INSTALL_DIR/etc/profile.d/conda.sh $CONDA_INSTALL_ENV"
+      echo " $ conda activate base"
+      echo " $ conda activate $CONDA_INSTALL_ENV"
       [[ $INSTALL_PRODUCTION ]] && echo " cgat --help"
       echo
       echo " To deactivate the environment, use:"
-      echo " $ source deactivate"
+      echo " $ conda deactivate"
       echo
    fi # if-$ conda create
 
@@ -706,6 +708,7 @@ test_compilers() {
    which gcc &> /dev/null || report_error " C compiler not found "
    which g++ &> /dev/null || report_error " C++ compiler not found "
 }
+
 
 # function to display help message
 help_message() {

--- a/install-CGAT-tools.sh
+++ b/install-CGAT-tools.sh
@@ -701,6 +701,14 @@ test_release() {
 }
 
 
+# test whether a C/C++ compiler is available
+test_compilers() {
+   which gcc &> /dev/null
+   [[ $? -ne 0 ]] && report_error " C compiler not found. "
+   which g++ &> /dev/null
+   [[ $? -ne 0 ]] && report_error " C++ compiler not found. "
+}
+
 # function to display help message
 help_message() {
 echo
@@ -736,6 +744,8 @@ exit 1
 } # help_message
 
 # the script starts here
+
+test_compilers
 
 if [[ $# -eq 0 ]] ; then
 


### PR DESCRIPTION
Due to the new way we use conda environments in the code, and a change in the way that conda environments are [handled](https://github.com/conda/conda/blob/master/CHANGELOG.md#440-2017-12-20), the docs need updating.

Also, the GCC package in conda [seems](https://github.com/ContinuumIO/anaconda-issues/issues/5191) to be deprecated and therefore we need to rely now on a local C/C++ compiler on the target machine. Added a test to check for compilers before performing the installation. Removed `gcc` packages in [here](https://github.com/cgat-developers/cgat-apps/compare/b1bf0298f984...1f3ebb10ec9b)
