### PR TITLE
Fix #46

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,9 @@ env:
     - TEST_ALL=1
 
 # Using xvfb to Run Tests That Require a GUI
-# NOTE: The "before_script" section below does not work properly, but right now is not required
-# Linux: https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-#  OS X:https://github.com/travis-ci/travis-ci/issues/7313#issuecomment-279914149
-before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3 ; fi 
-#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8 && echo ok )& ; fi
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
+services:
+  - xvfb
 
 script: 
   - travis_wait 30 ./install.sh --travis

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ CGAT Apps is a collection of scripts to analyse high-throughput sequencing data.
 
 After installation, use the ``cgat`` command to see how to use them.
 
-We are attempting to improve our documentation. However, our current docuemtation
+We are attempting to improve our documentation. However, our current documentation
 can be found `here <https://www.cgat.org/downloads/public/cgat/documentation/>`_
 
 For questions, please open a discussion on the GitHub 

--- a/conda/environments/cgat-apps.yml
+++ b/conda/environments/cgat-apps.yml
@@ -40,6 +40,7 @@ dependencies:
 - bedtools
 - coreutils
 - grep
+- htslib
 - libpng
 - samtools
 - sra-tools

--- a/install.sh
+++ b/install.sh
@@ -107,11 +107,11 @@ else
    fi
 
    if [[ $INSTALL_PRODUCTION ]] ; then
-      CONDA_INSTALL_TYPE_APPS="apps-production.yml"
-      CONDA_INSTALL_TYPE_CORE="core-production.yml"
+      CONDA_INSTALL_TYPE_APPS="cgat-apps.yml"
+      CONDA_INSTALL_TYPE_CORE="cgat-core.yml"
    elif [[ $INSTALL_DEVEL ]] ; then
-      CONDA_INSTALL_TYPE_APPS="apps-devel.yml"
-      CONDA_INSTALL_TYPE_CORE="core-devel.yml"
+      CONDA_INSTALL_TYPE_APPS="cgat-apps.yml"
+      CONDA_INSTALL_TYPE_CORE="cgat-core.yml"
    elif [[ $INSTALL_TEST ]] || [[ $INSTALL_UPDATE ]] ; then
       if [[ -d $CGAT_HOME/conda-install ]] ; then
          AUX=`find $CGAT_HOME/conda-install/envs/cgat-* -maxdepth 0`


### PR DESCRIPTION

Hi @kevinrue 

Thanks for reporting #46 

We used to have "production" and "devel" environments but that's changed over time and the install script hasn't been updated accordingly.

Here is my suggested change. The code currently looks redundant but I would like to leave the if/then/else statement in place in case we think it is useful to go back to "production" and "devel" environments.

Please test and confirm whether it works for you.

Best regards,
Sebastian

PS1: Also Travis has changed the default Ubuntu from Trusty to Xenial, which changed the way xvfb works, and I have updated the .travis.yml accordingly;
https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui

PS2: I had to add **htslib** as an explicit dependency to the cgat-apps.yml, to avoid errors like
```
/home/travis/build/cgat-developers/cgat-apps/conda-install/envs/cgat-a/compiler_compat/ld: cannot find -lhts
```
See example in: https://travis-ci.org/cgat-developers/cgat-apps/builds/574429702
