### PR TITLE
Fix ArgParser compatibility code error

### DIFF
--- a/cgat/tools/bam2geneprofile.py
+++ b/cgat/tools/bam2geneprofile.py
@@ -596,7 +596,7 @@ def main(argv=None):
 
     # Keep for backwards compatability
     if len(unknown) == 2:
-        infile, gtf = args
+        infile, gtf = unknown
         args.infiles.append(infile)
         args.gtffile = gtf
 


### PR DESCRIPTION
the variables infile, gtf are found in the variable unknown, not in the namespace args