### PR TITLE
{is} bam2geneprofile bigwig

### DIFF
--- a/cgat/BamTools/geneprofile.pyx
+++ b/cgat/BamTools/geneprofile.pyx
@@ -470,17 +470,24 @@ class RangeCounterBigWig(RangeCounter):
             for start, end in ranges:
                 length = end - start
 
+                if contig not in wigfile.chroms():
+                    continue
+                
                 values = wigfile.values(contig, start, end)
                 if values == None:
                     continue
 
-                for tstart, tend, value in values:
-                    rstart = tstart - start + current_offset
-                    rend = tend - start + current_offset
-                    for i from rstart <= i < rend: counts[i] = value
+                for tstart, value in enumerate(values):
+                    rstart = tstart + current_offset
+
+                    # check for nan values
+                    if value != value:
+                        value = 0.0
+                    counts[rstart] = value
                     
                 current_offset += length
-
+       
+        
 class IntervalsCounter:
     '''aggregate reads/intervals within a certain arrangement of
     intervals (sections). Sections are defined by a transcript-model 

--- a/cgat/BamTools/geneprofile.pyx
+++ b/cgat/BamTools/geneprofile.pyx
@@ -455,8 +455,7 @@ class RangeCounterBigWig(RangeCounter):
     def count(self, counts, files, contig, ranges ):
         
         # collect pileup profile in region bounded by start and end.
-        cdef int i
-        cdef int rstart, rend, start, end, tstart, tend
+        cdef int rstart, start, end, tstart
 
         if len(ranges) == 0:
             return
@@ -483,6 +482,7 @@ class RangeCounterBigWig(RangeCounter):
                     # check for nan values
                     if value != value:
                         value = 0.0
+
                     counts[rstart] = value
                     
                 current_offset += length


### PR DESCRIPTION
Addresses #36 and #67.

Mostly completing the changes so that bam2geneprofile uses pyBigWig rather than bx-python. 

Also adds routines that checks if the requested intervals were
1. Zero length
2. Go off the end of the contig.

Currently going off the 5' end of the contig is checked by the the (Gene/UTR/Intron etc)Counters, while the 3' is only checked in IntervalCounterBigWig. 3' ends should probably be checked for BAM based counting as well (3' ends can't be checked for Bed based counting). 

Currently the Signal file backed counters are the only ones with access to the contig sizes. This makes sense, because whether or not they are available depends on the type of file backing them. The interval backed counters are the ones that know if an interval is a primary interval or a flank. 

Both 3' and 5' checks should be moved to one or the other, and extended to all file types (where possible). But not clear how to do this. 
