### PR TITLE
libcalignmentfile cimports

### DIFF
--- a/cgat/BamTools/geneprofile.pyx
+++ b/cgat/BamTools/geneprofile.pyx
@@ -1,7 +1,7 @@
 #cimport csamtools
 
 from pysam.libchtslib cimport *
-from pysam.libcalignmentfile cimport *
+from pysam.libcalignmentfile cimport AlignmentFile, AlignedSegment
 import pysam
 
 import collections, array, struct, sys, itertools

--- a/cgat/BamTools/peakshape.pyx
+++ b/cgat/BamTools/peakshape.pyx
@@ -1,6 +1,6 @@
 #cimport csamtools
 
-from pysam.libcalignmentfile cimport *
+from pysam.libcalignmentfile cimport AlignmentFile, AlignedSegment
 import collections
 import cgatcore.experiment as E
 import numpy

--- a/cgat/GeneModelAnalysis.pyx
+++ b/cgat/GeneModelAnalysis.pyx
@@ -1,7 +1,7 @@
 # cython: profile=True
 #cimport csamtools
 from pysam.libchtslib cimport *
-from pysam.libcalignmentfile cimport *
+from pysam.libcalignmentfile cimport AlignedSegment
 from posix.stdlib cimport drand48
 
 import collections, array, struct


### PR DESCRIPTION
Fixes for #111, currently only for libcalalignment which causes most errors.
Needed for higher version of pysam to work on cgatflow